### PR TITLE
Better asset sales management when rebalancing

### DIFF
--- a/investools/model/__init__.py
+++ b/investools/model/__init__.py
@@ -1,4 +1,4 @@
-from .account import Account, AssetLot, TaxationClass
+from .account import Account, AssetLot, HoldTerm, TaxationClass
 from .allocation import Allocation
 from .asset import Asset, AssetClass
 from .config import Config
@@ -11,6 +11,7 @@ __all__ = [
     "AssetClass",
     "AssetLot",
     "Config",
+    "HoldTerm",
     "Portfolio",
     "TaxationClass",
 ]

--- a/investools/model/account.py
+++ b/investools/model/account.py
@@ -15,11 +15,49 @@ class TaxationClass(enum.Enum):
     TAX_EXEMPT = "TaxExempt"
 
 
+class GoogleSheetDateTime(datetime.datetime):
+
+    START_DATE = datetime.datetime(1899, 12, 30)
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value):
+        if not isinstance(value, int):
+            raise TypeError("int required")
+
+        return cls.START_DATE + datetime.timedelta(days=value)
+
+
+class HoldTerm(enum.Enum):
+
+    SHORT = enum.auto()
+    LONG = enum.auto()
+
+
 class AssetLot(BaseModel):
 
     ticker: str
     shares: float = pydantic.Field(0.0, ge=0.0)
-    # TODO purchase_date
+    purchase_date: t.Optional[GoogleSheetDateTime]
+    purchase_price: t.Optional[float]
+
+    @property
+    def days_held(self) -> t.Optional[int]:
+        if self.purchase_date is None:
+            return None
+
+        delta = datetime.datetime.today() - self.purchase_date
+        return delta.days
+
+    @property
+    def hold_term(self) -> t.Optional[HoldTerm]:
+        if self.days_held is None:
+            return None
+
+        return HoldTerm.LONG if self.days_held > 365 else HoldTerm.SHORT
 
 
 class Account(BaseModel):

--- a/investools/model/account.py
+++ b/investools/model/account.py
@@ -20,11 +20,11 @@ class GoogleSheetDateTime(datetime.datetime):
     START_DATE = datetime.datetime(1899, 12, 30)
 
     @classmethod
-    def __get_validators__(cls):
+    def __get_validators__(cls) -> t.Iterator[t.Callable[[t.Any], t.Any]]:
         yield cls.validate
 
     @classmethod
-    def validate(cls, value):
+    def validate(cls, value: t.Any) -> datetime.datetime:
         if not isinstance(value, int):
             raise TypeError("int required")
 

--- a/investools/rebalancing.py
+++ b/investools/rebalancing.py
@@ -79,12 +79,8 @@ class Position:
         lot_iter = iter(
             sorted(
                 self._iter_asset_lots(),
-                key=(
-                    lambda lot: (
-                        bool(lot.purchase_date),
-                        lot.purchase_date,
-                    )
-                ),
+                key=_asset_lot_sale_order_sort_key,
+                reverse=True,
             )
         )
 
@@ -101,6 +97,20 @@ class Position:
                 asset_lot=lot_to_sell_from,
             )
             remaining_shares_to_sell -= share_count
+
+
+def _asset_lot_sale_order_sort_key(
+    lot: model.AssetLot,
+) -> t.Tuple[bool, t.Optional[float]]:
+    """
+    Sell assets starting with the highest purchase price first to minimize capital
+    gains / maximize capital losses
+    """
+    if not lot.purchase_price:
+        # Separate lots without a purchase price into their own section
+        return False, None
+
+    return True, lot.purchase_price
 
 
 class AllowedSales(enum.Enum):

--- a/investools/rebalancing.py
+++ b/investools/rebalancing.py
@@ -1,10 +1,37 @@
 import dataclasses
+import enum
 import functools
 import typing as t
 
 import pulp
 
 from . import model, returns
+
+
+@dataclasses.dataclass
+class Sale:
+
+    share_count: float
+    sale_price: float
+    asset_lot: model.AssetLot
+
+    @property
+    def cost_basis(self) -> t.Optional[float]:
+        if self.asset_lot.purchase_price is None:
+            return None
+
+        return self.share_count * self.asset_lot.purchase_price
+
+    @property
+    def proceeds(self) -> float:
+        return self.share_count * self.sale_price
+
+    @property
+    def capital_gains(self) -> t.Optional[float]:
+        if self.cost_basis is None:
+            return None
+
+        return self.proceeds - self.cost_basis
 
 
 @dataclasses.dataclass
@@ -33,12 +60,64 @@ class Position:
     def get_target_investment(self) -> float:
         return self.get_target_shares() * self.asset.share_price
 
+    def get_short_term_share_count(self) -> float:
+        return sum(
+            lot.shares
+            for lot in self._iter_asset_lots()
+            if lot.hold_term is model.HoldTerm.SHORT
+        )
 
-def rebalance(portfolio: model.Portfolio, no_sales: bool = False) -> t.List[Position]:
+    def _iter_asset_lots(self) -> t.Iterator[model.AssetLot]:
+        for lot in self.account.asset_lots:
+            if lot.ticker == self.asset.ticker:
+                yield lot
+
+    def generate_sales(self) -> t.Iterator[Sale]:
+        delta = self.get_delta()
+        remaining_shares_to_sell = abs(delta) if delta < 0 else 0
+
+        lot_iter = iter(
+            sorted(
+                self._iter_asset_lots(),
+                key=(
+                    lambda lot: (
+                        bool(lot.purchase_date),
+                        lot.purchase_date,
+                    )
+                ),
+            )
+        )
+
+        while remaining_shares_to_sell:
+            try:
+                lot_to_sell_from = next(lot_iter)
+            except StopIteration:
+                return
+
+            share_count = min(remaining_shares_to_sell, lot_to_sell_from.shares)
+            yield Sale(
+                share_count=share_count,
+                sale_price=self.asset.share_price,
+                asset_lot=lot_to_sell_from,
+            )
+            remaining_shares_to_sell -= share_count
+
+
+class AllowedSales(enum.Enum):
+
+    NONE = "none"
+    TAX_FREE = "tax-free"
+    LONG_TERM = "long-term"
+    ALL = "all"
+
+
+def rebalance(
+    portfolio: model.Portfolio, allowed_sales: AllowedSales
+) -> t.List[Position]:
     drift_limit = 0.0001
     while True:
         try:
-            return _try_rebalance(portfolio, drift_limit, no_sales)
+            return _try_rebalance(portfolio, drift_limit, allowed_sales)
         except CannotRebalance:
             drift_limit = drift_limit * 2
             if drift_limit > portfolio.config.drift_limit:
@@ -48,7 +127,7 @@ def rebalance(portfolio: model.Portfolio, no_sales: bool = False) -> t.List[Posi
 def _try_rebalance(
     portfolio: model.Portfolio,
     drift_limit: float,
-    no_sales: bool,
+    allowed_sales: AllowedSales,
 ) -> t.List[Position]:
 
     problem = pulp.LpProblem(name="Rebalance", sense=pulp.const.LpMaximize)
@@ -105,13 +184,31 @@ def _try_rebalance(
             f"drift_within_negative_limit_allocation_{allocation.id}",
         )
 
-    # Ensure there are no taxable asset sales
+    # Constrain based on allowed sale type
     for position in positions:
-        if no_sales or position.account.taxation_class is model.TaxationClass.TAXABLE:
+        if allowed_sales is AllowedSales.NONE:
             problem += (
                 position.target_shares_variable >= position.get_current_shares(),
                 f"no_sales_account_{position.account.id}_asset_{position.asset.ticker}",
             )
+        elif (
+            allowed_sales is AllowedSales.TAX_FREE
+            and position.account.taxation_class is model.TaxationClass.TAXABLE
+        ):
+            problem += (
+                position.target_shares_variable >= position.get_current_shares(),
+                f"no_taxable_sales_account_{position.account.id}_asset_{position.asset.ticker}",
+            )
+        elif (
+            allowed_sales is AllowedSales.LONG_TERM
+            and position.account.taxation_class is model.TaxationClass.TAXABLE
+        ):
+            short_term_share_count = position.get_short_term_share_count()
+            if short_term_share_count > 0:
+                problem += (
+                    position.target_shares_variable >= short_term_share_count,
+                    f"no_short_term_sales_account_{position.account.id}_asset_{position.asset.ticker}",
+                )
 
     projected_position_return_variables = _get_projected_position_return_variables(
         portfolio, positions


### PR DESCRIPTION
Previously, rebalancing would never allow sales in taxable accounts, but sales in tax-advantaged account were allowed unless the user passed `--no-sales`. 

This change replaces the `--no-sales` flag with a `--sales` option that allows:
* `none` (same as --no-sales): no sales allowed
* `tax-free` (the default): only sales in tax-advantaged accounts allowed
* `long-term`: `tax-free` plus any sales that would be given LTCG treatment are allowed
* `all`: all sales allowed

This also adds a new sales table to the rebalance output that displays exactly which lots from which accounts to sell, along with any corresponding capital gain/loss info.